### PR TITLE
Multiple Galeries using "data-gallery" attribute

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -76,13 +76,13 @@ header h2{
 	Thumbnails
 -----------------------------*/
 
-#thumbs{
+.thumbs{
 	width:480px;
 	margin:60px auto 35px;
 	text-align:center;
 }
 
-#thumbs a{
+.thumbs a{
 	width:120px;
 	height:120px;
 	display:inline-block;
@@ -101,7 +101,7 @@ header h2{
 	-webkit-background-size:cover;
 }
 
-#thumbs a:after{
+.thumbs a:after{
 	background-color: #303030;
     border-radius: 7px;
     bottom: -136px;

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -136,7 +136,7 @@ header h2{
 
 
 @media screen and (max-width: 960px) {
-	#thumbs, #credit{
+	.thumbs, #credit{
 		width:auto;
 	}
 	

--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -1,6 +1,6 @@
 $(function(){
 	
 	// Initialize the gallery
-	$('#thumbs a').touchTouch();
+	$('.thumbs a').touchTouch();
 
 });

--- a/assets/touchTouch/touchTouch.jquery.js
+++ b/assets/touchTouch/touchTouch.jquery.js
@@ -110,7 +110,7 @@
 			}
 
 			//These statements kept seperate in case elements have data-gallery on both
-			//items and ancestor. Ancestor will always win because above of above statments.
+			//items and ancestor. Ancestor will always win because of above statments.
 			if (galleryName && selectorType == 'item') {
 
 				items = $('[data-gallery='+galleryName+']');
@@ -119,8 +119,9 @@
 
 				//Filter to check if item has an ancestory with data-gallery attribute
 				items = items.filter(function(){
-					console.log($(this).parent().closest('[data-gallery]').length);
+
            			return $(this).parent().closest('[data-gallery]').length;    
+           			
            		});
 
 			}

--- a/assets/touchTouch/touchTouch.jquery.js
+++ b/assets/touchTouch/touchTouch.jquery.js
@@ -6,7 +6,12 @@
  * @license		MIT License
  */
 
+
 (function(){
+
+
+
+
 	
 	/* Private variables */
 	
@@ -20,6 +25,9 @@
 	/* Creating the plugin */
 	
 	$.fn.touchTouch = function(){
+
+
+
 		
 		var placeholders = $([]),
 			index = 0,
@@ -77,16 +85,33 @@
 		
 		items.on('click', function(e){
 			e.preventDefault();
-			
-			
+
+			var $this = $(this),
+				galleryName,
+				selectorType,
+				$closestGallery = $this.parent().closest('[data-gallery]');
+
 			// Find gallery name and change items object to only have 
 			// that gallery
-			var galleryName = $(this).attr('data-gallery');
 
-			if (galleryName) {
-				items = $('[data-gallery='+galleryName+']');
+			console.log($this.closest('[data-gallery]').attr('data-gallery'));
+
+			if ($this.attr('data-gallery')) {
+				galleryName = $this.attr('data-gallery');
+				selectorType = 'item';
+			} else if ($closestGallery.length) {
+				galleryName = $closestGallery.attr('data-gallery');
+				selectorType = 'parent';
 			}
 
+			
+	if (galleryName && selectorType == 'item') {
+				items = $('[data-gallery='+galleryName+']');
+			} else if (galleryName && selectorType == 'parent') {
+				items = items.filter(function(){
+           				 return $closestGallery.find(this); 
+           				});
+			}
 			// Find the position of this image
 			// in the collection
 			index = items.index(this);

--- a/assets/touchTouch/touchTouch.jquery.js
+++ b/assets/touchTouch/touchTouch.jquery.js
@@ -9,10 +9,6 @@
 
 (function(){
 
-
-
-
-	
 	/* Private variables */
 	
 	var overlay = $('<div id="galleryOverlay">'),
@@ -26,12 +22,10 @@
 	
 	$.fn.touchTouch = function(){
 
-
-
-		
 		var placeholders = $([]),
 			index = 0,
-			items = this;
+			allitems = this;
+			items = allitems;
 		
 		// Appending the markup to the page
 		overlay.hide().appendTo('body');
@@ -39,11 +33,13 @@
 		
 		// Creating a placeholder for each image
 		items.each(function(){
+
 			placeholders = placeholders.add($('<div class="placeholder">'));
 		});
 	
 		// Hide the gallery if the background is touched / clicked
 		slider.append(placeholders).on('click',function(e){
+
 			if(!$(e.target).is('img')){
 				hideOverlay();
 			}
@@ -64,10 +60,13 @@
 						e.originalEvent.changedTouches[0];
 				
 				if(touch.pageX - startX > 10){
+
 					slider.off('touchmove');
 					showPrevious();
 				}
+
 				else if (touch.pageX - startX < -10){
+
 					slider.off('touchmove');
 					showNext();
 				}
@@ -78,12 +77,14 @@
 			return false;
 			
 		}).on('touchend',function(){
+
 			slider.off('touchmove');
+
 		});
 		
 		// Listening for clicks on the thumbnails
-		
 		items.on('click', function(e){
+
 			e.preventDefault();
 
 			var $this = $(this),
@@ -94,24 +95,36 @@
 			// Find gallery name and change items object to only have 
 			// that gallery
 
-			console.log($this.closest('[data-gallery]').attr('data-gallery'));
-
+			//If gallery name given to each item
 			if ($this.attr('data-gallery')) {
+
 				galleryName = $this.attr('data-gallery');
 				selectorType = 'item';
+
+			//If gallery name given to some ancestor
 			} else if ($closestGallery.length) {
+
 				galleryName = $closestGallery.attr('data-gallery');
-				selectorType = 'parent';
+				selectorType = 'ancestor';
+
 			}
 
-			
-	if (galleryName && selectorType == 'item') {
+			//These statements kept seperate in case elements have data-gallery on both
+			//items and ancestor. Ancestor will always win because above of above statments.
+			if (galleryName && selectorType == 'item') {
+
 				items = $('[data-gallery='+galleryName+']');
-			} else if (galleryName && selectorType == 'parent') {
+
+			} else if (galleryName && selectorType == 'ancestor') {
+
+				//Filter to check if item has an ancestory with data-gallery attribute
 				items = items.filter(function(){
-           				 return $closestGallery.find(this); 
-           				});
+					console.log($(this).parent().closest('[data-gallery]').length);
+           			return $(this).parent().closest('[data-gallery]').length;    
+           		});
+
 			}
+
 			// Find the position of this image
 			// in the collection
 			index = items.index(this);
@@ -145,10 +158,11 @@
 		// Listen for arrow keys
 		$(window).bind('keydown', function(e){
 		
-			if (e.keyCode == 37){
+			if (e.keyCode == 37) {
 				showPrevious();
 			}
-			else if (e.keyCode==39){
+
+			else if (e.keyCode==39) {
 				showNext();
 			}
 	
@@ -159,7 +173,6 @@
 		
 	
 		function showOverlay(index){
-			
 			// If the overlay is already shown, exit
 			if (overlayVisible){
 				return false;
@@ -181,6 +194,7 @@
 		}
 	
 		function hideOverlay(){
+
 			// If the overlay is not shown, exit
 			if(!overlayVisible){
 				return false;
@@ -192,15 +206,20 @@
 
 			//Clear preloaded items
 			$('.placeholder').empty();
+
+			//Reset possibly filtered items
+			items = allitems;
 		}
 	
 		function offsetSlider(index){
+
 			// This will trigger a smooth css transition
 			slider.css('left',(-index*100)+'%');
 		}
 	
 		// Preload an image by its index in the items array
 		function preload(index){
+
 			setTimeout(function(){
 				showImage(index);
 			}, 1000);
@@ -224,6 +243,7 @@
 		// Returns a jQuery object
 		
 		function loadImage(src, callback){
+
 			var img = $('<img>').on('load', function(){
 				callback.call(img);
 			});
@@ -239,9 +259,9 @@
 				offsetSlider(index);
 				preload(index+1);
 			}
+
 			else{
 				// Trigger the spring animation
-				
 				slider.addClass('rightSpring');
 				setTimeout(function(){
 					slider.removeClass('rightSpring');
@@ -257,9 +277,9 @@
 				offsetSlider(index);
 				preload(index-1);
 			}
+
 			else{
 				// Trigger the spring animation
-				
 				slider.addClass('leftSpring');
 				setTimeout(function(){
 					slider.removeClass('leftSpring');

--- a/assets/touchTouch/touchTouch.jquery.js
+++ b/assets/touchTouch/touchTouch.jquery.js
@@ -24,7 +24,7 @@
 
 		var placeholders = $([]),
 			index = 0,
-			allitems = this;
+			allitems = this,
 			items = allitems;
 		
 		// Appending the markup to the page

--- a/assets/touchTouch/touchTouch.jquery.js
+++ b/assets/touchTouch/touchTouch.jquery.js
@@ -78,15 +78,17 @@
 		items.on('click', function(e){
 			e.preventDefault();
 			
-			// Find the position of this image
-			// in the collection
-
+			
+			// Find gallery name and change items object to only have 
+			// that gallery
 			var galleryName = $(this).attr('data-gallery');
 
 			if (galleryName) {
 				items = $('[data-gallery='+galleryName+']');
 			}
 
+			// Find the position of this image
+			// in the collection
 			index = items.index(this);
 			showOverlay(index);
 			showImage(index);
@@ -162,6 +164,9 @@
 			// Hide the overlay
 			overlay.hide().removeClass('visible');
 			overlayVisible = false;
+
+			//Clear preloaded items
+			$('.placeholder').empty();
 		}
 	
 		function offsetSlider(index){

--- a/assets/touchTouch/touchTouch.jquery.js
+++ b/assets/touchTouch/touchTouch.jquery.js
@@ -80,7 +80,13 @@
 			
 			// Find the position of this image
 			// in the collection
-			
+
+			var galleryName = $(this).attr('data-gallery');
+
+			if (galleryName) {
+				items = $('[data-gallery='+galleryName+']');
+			}
+
 			index = items.index(this);
 			showOverlay(index);
 			showImage(index);

--- a/index.html
+++ b/index.html
@@ -26,16 +26,19 @@
 			<h2>A gallery optimized for touch devices</h2>
 		</header>
 		
-        <div id="thumbs">
-	        <a href="http://farm8.staticflickr.com/7013/6754656011_3de2cc73a2_z.jpg" style="background-image:url(http://farm8.staticflickr.com/7013/6754656011_3de2cc73a2_m.jpg)" title="Lion Rock"></a>
-	        <a href="http://farm8.staticflickr.com/7042/6895252645_45f5dfffaa_z.jpg" style="background-image:url(http://farm8.staticflickr.com/7042/6895252645_45f5dfffaa_m.jpg)" title="Holsten Gate"></a>
-	        <a href="http://farm8.staticflickr.com/7183/6943277737_21b521659c_z.jpg" style="background-image:url(http://farm8.staticflickr.com/7183/6943277737_21b521659c_m.jpg)" title="Blue Hour"></a>
-	        <a href="http://farm8.staticflickr.com/7047/7000951429_5eae078a62_z.jpg" style="background-image:url(http://farm8.staticflickr.com/7047/7000951429_5eae078a62_m.jpg)" title="Waikato Landscape"></a>
-	        <a href="http://farm6.staticflickr.com/5346/7051537899_efc7a44830_z.jpg" style="background-image:url(http://farm6.staticflickr.com/5346/7051537899_efc7a44830_m.jpg)" title="Tauranga Bridge"></a>
-	        <a href="http://farm8.staticflickr.com/7268/6951148260_440661b4d1_z.jpg" style="background-image:url(http://farm8.staticflickr.com/7268/6951148260_440661b4d1_m.jpg)" title="East Coast"></a>
-	        <a href="http://farm8.staticflickr.com/7259/6930112984_5fcc076288_z.jpg" style="background-image:url(http://farm8.staticflickr.com/7259/6930112984_5fcc076288_m.jpg)" title="Cathedral Cove"></a>
-	        <a href="http://farm8.staticflickr.com/7276/6886626710_047cd03acb_z.jpg" style="background-image:url(http://farm8.staticflickr.com/7276/6886626710_047cd03acb_m.jpg)" title="The Pond"></a>
-	        <a href="http://farm8.staticflickr.com/7020/6683299491_f2b5f6aa8b_z.jpg" style="background-image:url(http://farm8.staticflickr.com/7020/6683299491_f2b5f6aa8b_m.jpg)" title="Good Night"></a>
+        <div class="thumbs">
+	        <a href="http://farm8.staticflickr.com/7013/6754656011_3de2cc73a2_z.jpg" data-gallery="one" style="background-image:url(http://farm8.staticflickr.com/7013/6754656011_3de2cc73a2_m.jpg)" title="Lion Rock"></a>
+	        <a href="http://farm8.staticflickr.com/7042/6895252645_45f5dfffaa_z.jpg" data-gallery="one" style="background-image:url(http://farm8.staticflickr.com/7042/6895252645_45f5dfffaa_m.jpg)" title="Holsten Gate"></a>
+	        <a href="http://farm8.staticflickr.com/7183/6943277737_21b521659c_z.jpg" data-gallery="one" style="background-image:url(http://farm8.staticflickr.com/7183/6943277737_21b521659c_m.jpg)" title="Blue Hour"></a>
+	        <a href="http://farm8.staticflickr.com/7047/7000951429_5eae078a62_z.jpg" data-gallery="one" style="background-image:url(http://farm8.staticflickr.com/7047/7000951429_5eae078a62_m.jpg)" title="Waikato Landscape"></a>
+        </div>
+
+        <div class="thumbs">
+	        <a href="http://farm6.staticflickr.com/5346/7051537899_efc7a44830_z.jpg" data-gallery="two" style="background-image:url(http://farm6.staticflickr.com/5346/7051537899_efc7a44830_m.jpg)" title="Tauranga Bridge"></a>
+	        <a href="http://farm8.staticflickr.com/7268/6951148260_440661b4d1_z.jpg" data-gallery="two" style="background-image:url(http://farm8.staticflickr.com/7268/6951148260_440661b4d1_m.jpg)" title="East Coast"></a>
+	        <a href="http://farm8.staticflickr.com/7259/6930112984_5fcc076288_z.jpg" data-gallery="two" style="background-image:url(http://farm8.staticflickr.com/7259/6930112984_5fcc076288_m.jpg)" title="Cathedral Cove"></a>
+	        <a href="http://farm8.staticflickr.com/7276/6886626710_047cd03acb_z.jpg" data-gallery="two" style="background-image:url(http://farm8.staticflickr.com/7276/6886626710_047cd03acb_m.jpg)" title="The Pond"></a>
+	        <a href="http://farm8.staticflickr.com/7020/6683299491_f2b5f6aa8b_z.jpg" data-gallery="two" style="background-image:url(http://farm8.staticflickr.com/7020/6683299491_f2b5f6aa8b_m.jpg)" title="Good Night"></a>
         </div>
 
 		<p id="credit">

--- a/index.html
+++ b/index.html
@@ -26,11 +26,11 @@
 			<h2>A gallery optimized for touch devices</h2>
 		</header>
 		
-        <div class="thumbs">
-	        <a href="http://farm8.staticflickr.com/7013/6754656011_3de2cc73a2_z.jpg" data-gallery="one" style="background-image:url(http://farm8.staticflickr.com/7013/6754656011_3de2cc73a2_m.jpg)" title="Lion Rock"></a>
-	        <a href="http://farm8.staticflickr.com/7042/6895252645_45f5dfffaa_z.jpg" data-gallery="one" style="background-image:url(http://farm8.staticflickr.com/7042/6895252645_45f5dfffaa_m.jpg)" title="Holsten Gate"></a>
-	        <a href="http://farm8.staticflickr.com/7183/6943277737_21b521659c_z.jpg" data-gallery="one" style="background-image:url(http://farm8.staticflickr.com/7183/6943277737_21b521659c_m.jpg)" title="Blue Hour"></a>
-	        <a href="http://farm8.staticflickr.com/7047/7000951429_5eae078a62_z.jpg" data-gallery="one" style="background-image:url(http://farm8.staticflickr.com/7047/7000951429_5eae078a62_m.jpg)" title="Waikato Landscape"></a>
+        <div class="thumbs" data-gallery="one">
+	        <a href="http://farm8.staticflickr.com/7013/6754656011_3de2cc73a2_z.jpg" style="background-image:url(http://farm8.staticflickr.com/7013/6754656011_3de2cc73a2_m.jpg)" title="Lion Rock"></a>
+	        <a href="http://farm8.staticflickr.com/7042/6895252645_45f5dfffaa_z.jpg" style="background-image:url(http://farm8.staticflickr.com/7042/6895252645_45f5dfffaa_m.jpg)" title="Holsten Gate"></a>
+	        <a href="http://farm8.staticflickr.com/7183/6943277737_21b521659c_z.jpg" style="background-image:url(http://farm8.staticflickr.com/7183/6943277737_21b521659c_m.jpg)" title="Blue Hour"></a>
+	        <a href="http://farm8.staticflickr.com/7047/7000951429_5eae078a62_z.jpg" style="background-image:url(http://farm8.staticflickr.com/7047/7000951429_5eae078a62_m.jpg)" title="Waikato Landscape"></a>
         </div>
 
         <div class="thumbs">

--- a/readme.md
+++ b/readme.md
@@ -29,11 +29,25 @@ You must pass anchor elements which point to images in their href attributes for
 
 ### Multiple Galleries
 
-To show specific sets of pictures, add a "data-gallery" attribute to the anchor tags you want in that set, with a unique value. If this attribute isn't added, all images will be displayed.
+To show specific sets of pictures, add a "data-gallery" attribute to <strong>either:</strong>
+
+Each of the anchor tags you want in that set, with a unique value. 
 
 ```html
 	<a href="image.jpg" data-gallery="hongkong" title="Lion Rock"></a>
 ```
+
+<strong>Or:</strong>
+
+Any ancestor containing the elements selected by the plugin. Note that this method takes priority if both are used on the same set.
+
+```html
+	<ul data-gallery="hongkong">
+		...
+	</ul>
+```
+
+Of course you can ignore all this and all selected elements will be displayed.
 
 ## License
 

--- a/readme.md
+++ b/readme.md
@@ -27,6 +27,14 @@ $(function(){
 
 You must pass anchor elements which point to images in their href attributes for the gallery to work. In addition to conveying which images are to be displayed in the gallery, this also provides a graceful fallback in case JavaScript is not available.
 
+### Multiple Galleries
+
+To show specific sets of pictures, add a "data-gallery" attribute to the anchor tags you want in that set, with a unique value. If this attribute isn't added, all images will be displayed.
+
+```html
+	<a href="http://farm8.staticflickr.com/7013/6754656011_3de2cc73a2_z.jpg" data-gallery="hongkong" style="background-image:url(http://farm8.staticflickr.com/7013/6754656011_3de2cc73a2_m.jpg)" title="Lion Rock"></a>
+```
+
 ## License
 
 Released under the MIT license

--- a/readme.md
+++ b/readme.md
@@ -20,7 +20,7 @@ After you do all this, simply call the gallery as a regular jQuery plugin:
 $(function(){
 
 	// Initialize the gallery
-	$('#thumbs a').touchTouch();
+	$('.thumbs a').touchTouch();
 
 });
 ```
@@ -32,7 +32,7 @@ You must pass anchor elements which point to images in their href attributes for
 To show specific sets of pictures, add a "data-gallery" attribute to the anchor tags you want in that set, with a unique value. If this attribute isn't added, all images will be displayed.
 
 ```html
-	<a href="http://farm8.staticflickr.com/7013/6754656011_3de2cc73a2_z.jpg" data-gallery="hongkong" style="background-image:url(http://farm8.staticflickr.com/7013/6754656011_3de2cc73a2_m.jpg)" title="Lion Rock"></a>
+	<a href="image.jpg" data-gallery="hongkong" style="background-image:url(image.jpg)" title="Lion Rock"></a>
 ```
 
 ## License

--- a/readme.md
+++ b/readme.md
@@ -32,7 +32,7 @@ You must pass anchor elements which point to images in their href attributes for
 To show specific sets of pictures, add a "data-gallery" attribute to the anchor tags you want in that set, with a unique value. If this attribute isn't added, all images will be displayed.
 
 ```html
-	<a href="image.jpg" data-gallery="hongkong" style="background-image:url(image.jpg)" title="Lion Rock"></a>
+	<a href="image.jpg" data-gallery="hongkong" title="Lion Rock"></a>
 ```
 
 ## License


### PR DESCRIPTION
Implementation of multiple galleries using a "data-gallery" attribute for each anchor tag. Simply filters the "items" object upon click of anchor tag. Also, placeholders are cleared upon gallery close to prevent weird gallery crossover issues.
