### PR TITLE
Updated to be compatible with jQuery.noConflict()

### DIFF
--- a/assets/touchTouch/touchTouch.jquery.js
+++ b/assets/touchTouch/touchTouch.jquery.js
@@ -7,7 +7,7 @@
  */
 
 
-(function(){
+(function($){
 
 	/* Private variables */
 	


### PR DESCRIPTION
if `jQuery.noConflict()` is enabled, then `$` is not available.  Since the very last line of this plugin passes `jQuery` into this function, we just need to add the `$` variable at the top so it will be available internally.
