### PR TITLE
overlayVisible thumbnail click bug

### DIFF
--- a/assets/touchTouch/touchTouch.jquery.js
+++ b/assets/touchTouch/touchTouch.jquery.js
@@ -180,6 +180,7 @@
 		function showOverlay(index){
 			// If the overlay is already shown, exit
 			if (overlayVisible){
+				offsetSlider(index);
 				return false;
 			}
 


### PR DESCRIPTION
I noticed that, when the overlay was already opened and a user clicked on a thumbnail, the index in the memory would change but the clicked image didn't show.
This is easily fixable by copying the `offsetSlider(index);` instruction inside the `overlayVisible` if.
Hope this is helpful.
